### PR TITLE
added About in Navbar

### DIFF
--- a/index_resolved.html
+++ b/index_resolved.html
@@ -33,6 +33,7 @@
           <li><a href="/challenges" data-route="/challenges" class="nav__link">Challenges</a></li>
           <li><a href="/editor" data-route="/editor" class="nav__link">Editor</a></li>
           <li><a href="/profile" data-route="/profile" class="nav__link">Profile</a></li>
+          <li><a href="/about" data-route="/about" class="nav__link">About</a></li>
         </ul>
       </nav>
       <button class="header__toggle" id="navToggle" aria-label="Open navigation menu">


### PR DESCRIPTION
I have added About section in Navbar so that users can get information about the website by clicking on it.
<img width="1773" height="93" alt="image" src="https://github.com/user-attachments/assets/33db4b16-58b9-467f-9c72-01d3f703ee26" />

Please merge this request and assign gssoc2025 label and appropriate level.
Solved issue #50