### PR TITLE
Fix footer community links

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,9 +116,14 @@
           <div class="footer__section">
             <h4>Community</h4>
             <ul>
-              <li><a href="#">GitHub</a></li>
-              <li><a href="#">Discord</a></li>
-              <li><a href="#">Twitter</a></li>
+              <div class="footer__section">
+  <h4>Community</h4>
+  <ul>
+    <li><a href="https://github.com/opensource-society" target="_blank" rel="noopener">GitHub</a></li>
+    <li><a href="https://discord.gg/your-discord-invite" target="_blank" rel="noopener">Discord</a></li>
+    <li><a href="https://twitter.com/opensource_soc" target="_blank" rel="noopener">Twitter</a></li>
+  </ul>
+</div>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Replaced broken footer links with real URLs for GitHub, Discord, and Twitter.

Closes #79
