### PR TITLE
fixing-challenge-highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <nav class="header__nav" id="navMenu">
           <ul class="nav__list">
             <li><a href="/" data-route="/" class="nav__link">Home</a></li>
-            <li><a href="pages/challenges.html" data-route="/challenges" class="nav__link active">Challenges</a></li>
+            <li><a href="pages/challenges.html" data-route="/challenges" class="nav__link">Challenges</a></li>
             <li><a href="pages/editor.html" data-route="/editor" class="nav__link">Editor</a></li>
             <li><a href="pages/profile.html" data-route="/profile" class="nav__link">Profile</a></li>
             <li><a href="/about" data-route="/about" class="nav__link">About</a></li>


### PR DESCRIPTION
<img width="714" height="141" alt="image" src="https://github.com/user-attachments/assets/ae5502a7-d3ec-4fae-a365-e5d73caa1b77" />

now the menu bar is not highlighting challenge the whole time. when we are bringing our cursor to another link, then that link is highlighted.