### PR TITLE
Corrected footer button links for Discord and GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
                   <i class="fab fa-github me-2"></i> GitHub
                 </a>
                 <a
-                  href="https://github.com/opensource-society/CodeClip"
+                  href="https://discord.gg/NmGyBWAE3b"
                   target="_blank"
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"
@@ -521,7 +521,7 @@
                 class="footer-contact-col d-flex flex-column align-items-center"
               >
                 <a
-                  href="https://github.com/opensource-society/CodeClip"
+                  href="https://github.com/opensource-society/CodeClip/issues"
                   target="_blank"
                   class="btn btn-primary footer-contact-btn"
                   style="max-width: 250px"


### PR DESCRIPTION
Closes the issue #211 
This PR fixes the incorrect redirection of two footer buttons, the "Discord" and "Open an Issue" under Contact Us in the footer:

- Discord now correctly opens the official Discord invite: https://discord.gg/NmGyBWAE3b
- Open an Issue now takes users to the issues tab of the GitHub repo: https://github.com/opensource-society/CodeClip/issues