### PR TITLE
Fix: Discord button now redirects to correct Discord invite link #258

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
               <i class="fab fa-github me-2"></i> GitHub
             </a>
             <a
-              href="https://discord.gg/your-server-code"
+              href="https://discord.gg/Nf2yBMHx"
               target="_blank"
               class="btn btn-primary mb-2 footer-contact-btn"
               style="max-width: 250px"


### PR DESCRIPTION
Updated Discord button in footer to redirect to the correct invite link: https://discord.gg/Nf2yBMHx
Closes #258