### PR TITLE
Fixed the spelling of LinkedIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,7 @@
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"
                 >
-                  <i class="fab fa-linkedin-in me-2"></i> Linkdin
+                  <i class="fab fa-linkedin-in me-2"></i> LinkedIn
                 </a>
                 
               </div>


### PR DESCRIPTION
Under Contact Us, the spelling of "LinkedIn" was incorrect. I have fixed it. 

Closes #312 

Typo is fixed! @adityai0 