### PR TITLE
Fix: Corrected 'Linkdin' typo to 'LinkedIn' in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,7 @@
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"
                 >
-                  <i class="fab fa-linkedin-in me-2"></i> Linkdin
+                  <i class="fab fa-linkedin-in me-2"></i> Linkedln
                 </a>
                 
               </div>


### PR DESCRIPTION
👨‍💻This PR fixes a small typo in the footer where "Linkdin" was incorrectly spelled. It is now corrected to "LinkedIn".

Fixes: #<issue-number>  <!-- Replace this with your actual issue number -->

😊
<img width="1647" height="580" alt="Screenshot 2025-07-30 010415" src="https://github.com/user-attachments/assets/40a9dee4-d825-4e6c-b057-eb4e70b3345b" />
<img width="1871" height="876" alt="Screenshot 2025-07-30 012406" src="https://github.com/user-attachments/assets/ef1ab4b3-882e-4fbf-bc02-3332dcebfe3e" />
@Harsh-26626 Kindly review this. I'm contributing under GSSOC'25.
