### PR TITLE
Fix: Improve responsive layout for filter-controls on Challenges page

### DIFF
--- a/pages/challenges.html
+++ b/pages/challenges.html
@@ -62,10 +62,6 @@
     <!-- Filter Controls -->
     <section class="challenges-filter" aria-labelledby="filters-heading">
       <div class="container filter-controls">
-        <div class="filter-group">
-  
-</div>
-
         <h2 id="filters-heading" class="visually-hidden">Filter Challenges</h2>
 
         <div class="filter-group">

--- a/styles/challenges.css
+++ b/styles/challenges.css
@@ -426,6 +426,12 @@ body {
   stroke: var(--text-color);
 }
 
+@media (max-width: 1020px) {
+  .search-group{
+    width: 100%;
+  }
+}
+
 /* === RESPONSIVE === */
 @media (max-width: 768px) {
   .nav__list {


### PR DESCRIPTION
Fixes: #349 
This PR improves the responsiveness of the filter-controls section on the Challenges page.


Steps to Reproduce (before fix):

1. Navigate to Challenges from the navbar.
2. Resize the window below 1020px.
3. Observe the layout break in the filter section.


Fixed Screenshot:

<img width="1174" height="272" alt="Screenshot 2025-07-31 214639" src="https://github.com/user-attachments/assets/d112230c-df2b-4728-92e9-6c4f555409ad" />


