### PR TITLE
fix: remove duplicate content in mobile view (#411)

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <!-- ================================ Header Section Start Here ================================ -->
     <header>
 <main>
-        <nav class="navbar navbar-expand-lg fixed-top custom-navbar">
+        <nav class="navbar navbar-expand-lg fixed-top ">
             <div class="container">
                 <a class="navbar-brand" href="#homeSection">Code<span>Clip</span></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
@@ -99,47 +99,6 @@
                 </div>
             </div>
         </nav>
-
-      <nav class="navbar navbar-expand-lg fixed-top">
-        <div class="container">
-          <a class="navbar-brand" href="#homeSection">Code<span>Clip</span></a>
-          <button
-            class="navbar-toggler"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-          >
-            <span class="navbar-toggler-icon"></span>
-          </button>
-          <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-              <li class="nav-item ">
-                <a
-                  class="active"
-                  aria-current="page"
-                  href="#top"
-                  >Home</a
-                >
-              </li>
-              <li class="nav-item">
-                <a href="../CodeClip/pages/challenges.html">Challenges</a>
-              </li>
-              <li class="nav-item">
-                <a href="#leaderboardSection">Leaderboard</a>
-              </li>
-              <li class="nav-item">
-                <a href="#aboutSection">About</a>
-              </li>
-              <li class="nav-item">
-                <a  href="#contactFooter">Contact</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </nav>
       </main>
     </header>
     <!-- ================================ Header Section Start Here ================================ -->


### PR DESCRIPTION
📱 Issue
Fixes #411 — In mobile view, the "About" and "Contact" sections were rendered twice.

 ✅ Fix Summary
- Removed duplicated components from the mobile menu layout.
- Verified responsive behavior using device emulator (≤768px resolution).
- Cleaned up navigation rendering for small screen sizes.

🧪 Test
- Confirmed "About" and "Contact" appear only once.
- Mobile menu opens and closes properly.

Fixes: #411
