### PR TITLE
Fix: Make logo on challenges.html clickable to navigate back to homepage (#449)

### DIFF
--- a/pages/challenges.html
+++ b/pages/challenges.html
@@ -25,7 +25,7 @@
   <header class="header" role="banner">
     <div class="container header__container">
       <div class="header__logo">
-        <span class="logo-text">CodeClip</span>
+        <a href="../index.html" class="logo-text">CodeClip</a>
       </div>
       <nav class="header__nav" id="navMenu" aria-label="Primary navigation">
         <ul class="nav__list">


### PR DESCRIPTION
Issue:
On the pages/challenges.html page, the CodeClip logo in the header does not link back to the homepage (index.html), causing inconsistency with the working "Home" link in the navbar. Users expect the logo to be clickable and redirect to the main page.

Fix:

    Wrapped the CodeClip logo text in an anchor (<a>) tag linking to ../index.html.

    Ensured the class logo remains on the anchor tag to preserve styling.

Benefits:

    Improves navigation consistency across the site.

    Meets user expectations by making the logo clickable.

Testing:

    Verified locally that clicking the logo on challenges.html redirects correctly to the homepage.

Related issue:
Fixes #449