### PR TITLE
Solved the issues #309

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
                 >
               </li>
               <li class="nav-item">
-                <a href="../CodeClip/pages/challenges.html">Challenges</a>
+                <a href="pages/challenges.html">Challenges</a>
               </li>
               <li class="nav-item">
                 <a href="#leaderboardSection">Leaderboard</a>

--- a/pages/challenges.html
+++ b/pages/challenges.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Bitcount:wght@100..900&family=Oooh+Baby&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
-  <link rel="stylesheet" href="/CodeClip/styles/challenges.css" />
+  <link rel="stylesheet" href="/styles/challenges.css" />
 
   <!-- ================ Favicon ================  -->
     <link


### PR DESCRIPTION
Title: Challenge link path not working after fork in live server.

Description: When the project is running after forking, the Challenge navbar link was broken. The link was pointing to **/get/CodeClip/pages/challenge.html** which caused a **Cannot Get error**.

Changes Made:
 Updated the link path so it correctly points to the local challenge page when using Live Server.

Result:

The challenge link now works both locally and in deployed version.

Fixes #309 