### PR TITLE
Fix#399: correct Discord button redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
                   <i class="fab fa-github me-2"></i> GitHub
                 </a>
                 <a
-                  href="https://github.com/opensource-society/CodeClip"
+                  href="https://discord.gg/NmGyBWAE3b"
                   target="_blank"
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"


### PR DESCRIPTION
The Discord button in the footer of index.html was incorrectly configured with a link to the project's GitHub repository instead of Discord server.
This change updates the href attribute in the button component to the correct Discord invite URL, ensuring users are directed to the right place.