### PR TITLE
Fix duplicate About/Contact links in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,36 +87,6 @@
     <!-- ================================ Header Section Start Here ================================ -->
     <header>
 <main>
-        <nav class="navbar navbar-expand-lg fixed-top custom-navbar">
-            <div class="container">
-                <a class="navbar-brand" href="#homeSection">Code<span>Clip</span></a>
-                <button  class="navbar-toggler" type="button" data-bs-toggle="collapse"
-                    data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent"
-                    aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                        <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="#homeSection">Home</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#challengeSection">Challenges</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#leaderboardSection">Leaderboard</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#aboutSection">About</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="#contactFooter">Contact</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
-        </nav>
-
       <nav class="navbar navbar-expand-lg fixed-top">
         <div class="container">
           <a class="navbar-brand" href="#homeSection">Code<span>Clip</span></a>
@@ -131,29 +101,24 @@
           >
             <span class="navbar-toggler-icon"></span>
           </button>
-          <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-              <li class="nav-item ">
-                <a
-                  class="active"
-                  aria-current="page"
-                  href="#top"
-                  >Home</a
-                >
-              </li>
-              <li class="nav-item">
-                <a href="../CodeClip/pages/challenges.html">Challenges</a>
-              </li>
-              <li class="nav-item">
-                <a href="#leaderboardSection">Leaderboard</a>
-              </li>
-              <li class="nav-item">
-                <a href="#aboutSection">About</a>
-              </li>
-              <li class="nav-item">
-                <a  href="#contactFooter">Contact</a>
-              </li>
-            </ul>
+           <div class="collapse navbar-collapse" id="navbarSupportedContent">
+              <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link active" aria-current="page" href="#homeSection">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#challengeSection">Challenges</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#leaderboardSection">Leaderboard</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#aboutSection">About</a>
+                        </li>
+                        <li class="nav-item">
+                    <a class="nav-link" href="#contactFooter">Contact</a>
+                  </li>
+                </ul>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
 What does this PR do?  
- Fixed duplicate "About" and "Contact" links in the navbar.  
- Kept only the clean navbar so links appear only once.  
- Verified that navbar toggler works properly.  

### Screenshots:  

**Before:**  
<img width="857" height="474" alt="Before" src="https://github.com/user-attachments/assets/c6655afd-b87e-4a28-898a-1479bfd4a499" />

**After:**  
<img width="872" height="467" alt="After" src="https://github.com/user-attachments/assets/d729c9f2-3db4-4729-abe3-029fc64d1216" />

