### PR TITLE
Fix: Add permissions for GitHub Actions PR Preview Deployment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,7 +10,7 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       pages: write
       id-token: write


### PR DESCRIPTION
This PR updates the workflow file .github/workflows/pr-preview.yml to *fix the 403 permission denied error* when deploying previews with GitHub Actions.

**Changes Made**

Added permissions: contents: write to the workflow job so that github-actions[bot] can push to the preview branch.

Ensured the deployment step uses the built-in GITHUB_TOKEN with the correct permissions.

**Why this change?**

The deploy step was failing with the following error:

remote: Permission to <repo>.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/...': The requested URL returned error: 403

This happened because the workflow did not have write access to repository contents.

**Impact**

Fixes deployment of PR preview to GitHub Pages.

Ensures contributors can see live previews for pull requests.
