### PR TITLE
[Feature] Add Copy-to-Clipboard Button for Snippets

### DIFF
--- a/index.html
+++ b/index.html
@@ -550,6 +550,14 @@
         </div>
       </div>
     </section>
+    <!-- ================= Saved Snippets (new) ================= -->
+    <section id="snippetsSection" class="container my-5">
+      <h3 class="secHeader"><span>Saved</span> Snippets</h3>
+      <p class="sec-subtitle">Your personal collection of handy code pieces — copy them with one click whenever you need.</p>
+      <div id="snippets"></div>
+    </section>
+
+    <!-- ===================Saved Snippetsend here ===============-->
 
     <!-- ================================ Footer Section Start Here ================================ -->
     <footer id="contactFooter">
@@ -649,5 +657,9 @@
 
     <!-- ================ Custom JS ================  -->
     <script src="scripts/main.js"></script>
+
+    <!-- Snippet list + copy feature -->
+    <script src="scripts/snippets.js"></script>
+
   </body>
 </html>

--- a/scripts/snippets.js
+++ b/scripts/snippets.js
@@ -1,0 +1,78 @@
+
+document.addEventListener("DOMContentLoaded", () => {
+  const host = document.getElementById("snippets");
+  if (!host) return;
+
+  // --- 1) Your Hello World snippet ---
+  const snippet = {
+    id: "hello-world",
+    title: "Hello World (JavaScript)",
+    lang: "JavaScript",
+    code: `console.log("Hello World");`,
+  };
+
+  // --- 2) Render card ---
+  host.innerHTML = `
+    <article class="snippet-card border rounded p-3 mb-3 bg-white" data-id="${snippet.id}">
+      <div class="d-flex justify-content-between align-items-start gap-2 mb-2">
+        <h5 class="m-0">
+          ${escapeHtml(snippet.title)}
+          <span class="badge bg-secondary ms-1">${escapeHtml(snippet.lang)}</span>
+        </h5>
+        <div class="snippet-actions d-inline-flex align-items-center gap-2">
+          <button class="btn btn-primary btn-sm btn-copy" aria-label="Copy snippet to clipboard">📋 Copy</button>
+          <span class="copy-toast text-success small" aria-live="polite" hidden>Copied!</span>
+        </div>
+      </div>
+      <pre class="snippet-pre mb-0"><code class="snippet-code">${escapeHtml(snippet.code)}</code></pre>
+    </article>
+  `;
+
+  // --- 3) Wire up the Copy button (with fallback + toast) ---
+  host.addEventListener("click", (e) => {
+    const btn = e.target.closest(".btn-copy");
+    if (!btn) return;
+
+    const card = btn.closest(".snippet-card");
+    const codeNode = card?.querySelector(".snippet-code");
+    const toast = card?.querySelector(".copy-toast");
+    const text = codeNode?.innerText ?? "";
+
+    copyTextToClipboard(text)
+      .then(() => showToast(toast, "Copied!"))
+      .catch(() => showToast(toast, "Copy failed"));
+  });
+});
+
+/* ================= helpers ================= */
+
+function escapeHtml(str = "") {
+  return str.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function copyTextToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fallback for older browsers
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.left = "-9999px";
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    document.execCommand("copy");
+  } finally {
+    document.body.removeChild(ta);
+  }
+  return Promise.resolve();
+}
+
+function showToast(node, msg = "Copied!") {
+  if (!node) return;
+  node.textContent = msg;
+  node.hidden = false;
+  clearTimeout(node._t);
+  node._t = setTimeout(() => (node.hidden = true), 1600);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -824,6 +824,57 @@ footer .row.align-items-start {
   border-top: 1px solid #e5e7eb;
   padding: 2.5rem 0 1.5rem;
 }
+/*========= Snippets Section ========== */
+
+#snippetsSection {
+  margin-top: 2rem;
+}
+
+#snippetsSection .secHeader {
+  margin-bottom: .25rem;
+}
+
+#snippetsSection .sec-subtitle {
+  margin-bottom: 1rem;
+  color: #6b7280; 
+  font-size: 0.95rem;
+}
+
+.snippet-card {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+  transition: transform .15s ease-in-out, box-shadow .15s ease-in-out;
+}
+.snippet-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.10);
+}
+
+.snippet-pre {
+  background: #f8f9fa;
+  border-radius: 6px;
+  padding: .75rem;
+  overflow-x: auto;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  color: #111827; 
+}
+
+.snippet-actions .btn-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: .25rem;
+}
+
+.snippet-actions .btn-copy:focus {
+  outline: 2px solid #5b9dd9;
+  outline-offset: 2px;
+}
+
+.copy-toast {
+  margin-left: .25rem;
+}
+
 
 /* ===== Responsive ===== */
 @media (max-width: 991px) {


### PR DESCRIPTION
### Summary
Added a "Copy to Clipboard" button for each saved snippet.

### Motivation
Currently, users need to manually select and copy code. This feature improves usability by allowing one-click copying.

### Changes Made
- Added a "Copy" button to snippet cards in `index.html`.
- Implemented `scripts/snippets.js` with clipboard functionality and confirmation.
- Updated `styles/main.css` for button styling.
- Updated sample snippet text for better readability.

### Additional Context
This is part of GSSoC’25 contributions.  

