### PR TITLE
Removed redundant footer nav links since navbar is sticky

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,15 +573,7 @@
               (GSSoC) 2025 to open for contribution
             </p> 
           </div>
-          <div data-aos-duration="650" data-aos="fade-left" class="col-12 col-md-6 mb-4 mb-md-0 footer-links-col">
-            <h5 class="footer-title">Important Links</h5>
-            <ul class="footer-links list-unstyled mb-0">
-              <li><a href="#top">Home</a></li>
-              <li><a href="#challengeSection">Challenges</a></li>
-              <li><a href="#leaderboardSection">Leaderboard</a></li>
-              <li><a href="#aboutSection">About</a></li>
-            </ul>
-          </div>
+          <!-- Removed footer nav links when navbar is sticky issue #610 -->
           <div class="col-12 col-md-6 footer-contact-col-main">
             <h5 data-aos-duration="650" data-aos="fade-left" class="footer-title">Contact Us</h5>
             <div class="footer-contact-row d-flex justify-content-center">


### PR DESCRIPTION
Pull Request

Issue Linked:
Fixes #610 

Description:
This PR removes the duplicate navigation links from the footer since the navbar is sticky and always visible.
	•	Cleaned up the footer section by keeping only essential elements (copyright, socials).
	•	Improves UI/UX by avoiding redundant navigation.

Motivation:
	•	Navbar is sticky, so footer nav links are unnecessary.
	•	Creates a cleaner, more professional footer layout.

Screenshots:

Before:-

<img width="3420" height="2214" alt="Screenshot 2025-09-06 at 1 05 41 AM" src="https://github.com/user-attachments/assets/61b8d2f0-2d44-4f7e-9f29-e387d99bfc7e" />


After:-

<img width="3420" height="2214" alt="Screenshot 2025-09-07 at 9 30 56 PM" src="https://github.com/user-attachments/assets/42f80255-ae84-43f1-a682-87dfd3d84194" />
