### PR TITLE
Fix incorrect redirection of footer "Discord" and "Open an Issue" buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@
                   <i class="fab fa-github me-2"></i> GitHub
                 </a>
                 <a
-                  href="https://github.com/opensource-society/CodeClip"
+                  href="https://discord.gg/NmGyBWAE3b"
                   target="_blank"
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"
@@ -602,7 +602,7 @@
               >
               <!-- margin added -->
                 <a
-                  href="https://github.com/opensource-society/CodeClip"
+                  href="https://github.com/opensource-society/CodeClip/issues"
                   target="_blank"
                   class="btn btn-primary mb-2 footer-contact-btn"
                   style="max-width: 250px"


### PR DESCRIPTION
🚀 Pull Request

🔖 Description

This PR fixes the incorrect redirection of the footer buttons under Contact Us.
	•	Discord now points to: https://discord.gg/NmGyBWAE3b
	•	Open an Issue now points to: https://github.com/opensource-society/CodeClip/issues

Fixes: issue #614 

⸻

📸 Screenshots
Before:-


https://github.com/user-attachments/assets/d10e6ec3-0c8f-4d1d-8c40-4b21912baba2



After:-


https://github.com/user-attachments/assets/8777dad9-6e1d-43c8-9e2e-4d38fdf428b4


