### PR TITLE
Fix: Align footer contact buttons and set equal size (#628)

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
                 </a>
               </div>
               <div data-aos-duration="650" data-aos="fade-left"
-                class="footer-contact-col d-flex flex-column align-items-center"
+                class="footer-contact-col d-flex flex-column align-items-center last-two-buttons"
               >
               <!-- margin added -->
                 <a
@@ -613,7 +613,7 @@
                 <a
                   href="https://www.linkedin.com/in/adityai0"
                   target="_blank"
-                  class="btn btn-primary mb-2 footer-contact-btn mt-3 "
+                  class="btn btn-primary mb-2 footer-contact-btn mt-3"
                   style="max-width: 250px"
                 >
                   <i class="fab fa-linkedin-in me-2"></i> LinkedIn

--- a/styles.css
+++ b/styles.css
@@ -961,3 +961,11 @@ body {
         transform: rotate(360deg);
     }
 }
+.last-two-buttons{
+  margin-left:150px;
+}
+.footer-contact-btn {
+  width: 250px;   
+  max-width: 100%; 
+  text-align: left; 
+}


### PR DESCRIPTION
# Fix: Align 'Contact Us' Section Buttons for Improved Responsiveness #[628]

# Description
This pull request resolves a UI alignment issue within the "Contact Us" section on the CodeClip page. Previously, the contact buttons (GitHub, Discord, LinkedIn, etc.) appeared misaligned and unevenly spaced, which was particularly noticeable on smaller screen sizes and mobile devices.

The implemented changes ensure the buttons are now properly aligned, evenly spaced, and fully responsive, providing a clean and consistent user experience across all viewports.

# ScreenShots

<img width="1881" height="551" alt="Screenshot 2025-09-16 102101" src="https://github.com/user-attachments/assets/9bee588e-1130-4c9f-abdb-d9a84e70595d" />

# CheckList
 I have performed a self-review of my own code.

 My changes do not introduce any new errors or warnings.

My code follows the project's style guidelines.