### PR TITLE
fixed a typo in backend comment and changed Easy -> EASY for consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
                 </p>
 
                 <div class="card-CTAButton">
-                  <!-- === Create webpage of backend bbasic and add link here === -->
+                  <!-- === Create webpage of backend basic and add link here === -->
                   <a href="backendChallenges.html" class="card-Btn">Join Now</a>
                 </div>
               </div>
@@ -352,7 +352,7 @@
               <div class="card-body">
                 <div class="card-TopContainer">
                   <h5 class="card-Header">JavaScript Mini Projects</h5>
-                  <p class="card-Level medium-Col">Easy</p>
+                  <p class="card-Level medium-Col">EASY</p>
                   <div class="icon-container">
                     <i class="devicon-javascript-plain colored" title="JavaScript"></i>
                     <i class="devicon-css3-plain colored" title="CSS3"></i>


### PR DESCRIPTION
2 changes have been done:
1. fixed a small typo in a comment

before:
<img width="1391" height="868" alt="before_typo" src="https://github.com/user-attachments/assets/9e3dd3bb-834e-430a-a870-6706cc776b6e" />
after:
<img width="1387" height="877" alt="after_typoedit" src="https://github.com/user-attachments/assets/ebbbefe1-37b5-4d72-b450-b773a050faa6" />

2. changed Easy -> EASY for consistency
before:
<img width="1919" height="943" alt="before_change" src="https://github.com/user-attachments/assets/615b1537-b8d9-4ccc-8661-490c666f0b2c" />
after:
<img width="1910" height="946" alt="after_change" src="https://github.com/user-attachments/assets/89bb4db7-61da-4f71-a500-7cb6b57b45a8" />

